### PR TITLE
allow ProgramPath to be overridable via an environment variable

### DIFF
--- a/src/xeMeta.pas
+++ b/src/xeMeta.pas
@@ -291,6 +291,8 @@ end;
 
 {$region 'API functions'}
 procedure InitXEdit; cdecl;
+var
+  ProgramPath: String;
 begin
   // initialize variables
   _store := TInterfaceList.Create;
@@ -302,8 +304,24 @@ begin
   // add welcome message
   AddMessage('XEditLib v' + ProgramVersion);
 
+  // resolve program path; we allow the program path default value to be
+  // overridden with an `XEDITLIB_PROGRAM_PATH` environment variable. If
+  // not provided or value is empty, the program path will default to the
+  // directory of the first parameter of the command line, which is typically
+  // the path of the program executable
+  //
+  // overriding the program path is useful for scenarios where XEditLib.dll
+  // is being wrapped by an interpreted language, in which case the program
+  // executable may be the path to the interpreter, which can be located in
+  // some system folder where data files related to XEditLib.dll cannot and
+  // should not be expected to be located at.
+  ProgramPath := GetEnvironmentVariable('XEDITLIB_PROGRAM_PATH');
+  if ProgramPath = '' then begin
+    ProgramPath := ExtractFilePath(ParamStr(0));
+  end;
+
   // store global values
-  Globals.Values['ProgramPath'] := ExtractFilePath(ParamStr(0));
+  Globals.Values['ProgramPath'] := ProgramPath;
   Globals.Values['Version'] := ProgramVersion;
   Globals.Values['FileCount'] := '0';
 end;


### PR DESCRIPTION
Closes #16

Hi Mator, when last we talked about #16 (over a brief conversation on discord and then a reddit message), you mentioned that the `Hardcoded.dat` files are going away, so for a while I waited for your new update. Since it's been almost a year now and still no update, I figured I'd give it a stab.

I'm hoping that if you're okay with the code, then perhaps this can get the tiniest minor version release (like maybe v0.6.1) built out. With it, there would no longer be a blocker for me uploading my python wrapper to PyPI. Meanwhile when you do get around to removing the `Hardcoded.dat` files, there's no need to preserve this after.

I tested this change manually with `GetGlobal` and `ElementCount` and it seems to have the desired effect. That said, I've never worked with Delphi in my life and just getting it to compile took a few hours. The dll I built out seems to error on some more advanced xedit-lib workflows beyond `GetGlobal` and `ElementCount`, which I chalked up to project configuration issues, but if there's something egregiously wrong with the code please let me know.

Thanks,
leontristain