### PR TITLE
Add VR support to xedit-lib

### DIFF
--- a/src/xeConfiguration.pas
+++ b/src/xeConfiguration.pas
@@ -173,7 +173,7 @@ begin
   case wbGameMode of
     gmFO4VR: DefineFO4;
     gmFO4: DefineFO4;
-    gmTES5VR: DefineTES5
+    gmTES5VR: DefineTES5;
     gmSSE: DefineTES5;
     gmTES5: DefineTES5;
     gmFNV: DefineFNV;

--- a/src/xeConfiguration.pas
+++ b/src/xeConfiguration.pas
@@ -37,7 +37,7 @@ var
 
 const
   {$region 'Game modes'}
-  GameArray: array[0..5] of TGameMode = (
+  GameArray: array[0..7] of TGameMode = (
     ( longName: 'Fallout New Vegas'; gameName: 'FalloutNV'; gameMode: gmFNV;
       regName: 'FalloutNV'; appName: 'FNV'; exeName: 'FalloutNV.exe';
       appIDs: '22380,2028016'; ),
@@ -55,7 +55,13 @@ const
       exeName: 'SkyrimSE.exe'; appIDs: '489830'; ),
     ( longName: 'Fallout 4'; gameName: 'Fallout4'; gameMode: gmFO4;
       regName: 'Fallout4'; appName: 'FO4'; exeName: 'Fallout4.exe';
-      appIDs: '377160'; )
+      appIDs: '377160'; ),
+    ( longName: 'Skyrim VR'; gameName: 'Skyrim'; gameMode: gmTES5VR;
+      regName: 'Skyrim VR'; appName: 'TES5VR';
+      exeName: 'SkyrimVR.exe'; appIDs: '611670'; ),
+    ( longName: 'Fallout 4 VR'; gameName: 'Fallout4'; gameMode: gmFO4VR;
+      regName: 'Fallout 4 VR'; appName: 'FO4VR';
+      exeName: 'Fallout4VR.exe'; appIDs: '611660'; )
   );
   {$endregion}
   {$region 'TES4Languages'}
@@ -105,7 +111,7 @@ end;
 function GetLanguage: String;
 begin
   Result := Language;
-  if (wbGameMode = gmFO4) and (slLanguageMap.IndexOfName(Result) > -1) then
+  if (wbGameMode in [gmFO4, gmFO4VR]) and (slLanguageMap.IndexOfName(Result) > -1) then
     Result := slLanguageMap.Values[Result];
 end;
 
@@ -113,7 +119,7 @@ function GetLanguageEncoding: TwbStringEncoding;
 begin
   Result := seCP1252;
   if (slUTF8Languages.IndexOf(Language) > -1)
-  or ((wbGameMode in [gmSSE, gmFO4]) and (Language <> 'English')) then
+  or ((wbGameMode in [gmSSE, gmFO4, gmTES5VR, gmFO4VR]) and (Language <> 'English')) then
     Result := seUTF8;
 end;
 
@@ -142,10 +148,10 @@ begin
   wbGameMode := GameMode.gameMode;
   wbAppName := GameMode.appName;
   wbDataPath := dataPath;
-  wbVWDInTemporary := wbGameMode in [gmSSE, gmTES5, gmFO3, gmFNV];
-  wbVWDAsQuestChildren := wbGameMode = gmFO4;
-  wbArchiveExtension := IfThen(wbGameMode = gmFO4, '.ba2', '.bsa');
-  wbLoadBSAs := wbGameMode in [gmFO4, gmSSE, gmTES5, gmTES4];
+  wbVWDInTemporary := wbGameMode in [gmTES5VR, gmSSE, gmTES5, gmFO3, gmFNV];
+  wbVWDAsQuestChildren := wbGameMode in [gmFO4VR, gmFO4];
+  wbArchiveExtension := IfThen(wbGameMode in [gmFO4VR, gmFO4], '.ba2', '.bsa');
+  wbLoadBSAs := wbGameMode in [gmFO4VR, gmFO4, gmTES5VR, gmSSE, gmTES5, gmTES4];
   wbSimpleRecords := False;
   wbDisplayLoadOrderFormID := True;
   wbSortSubRecords := True;
@@ -165,8 +171,10 @@ begin
 
   // load definitions
   case wbGameMode of
-    gmSSE: DefineTES5;
+    gmFO4VR: DefineFO4;
     gmFO4: DefineFO4;
+    gmTES5VR: DefineTES5
+    gmSSE: DefineTES5;
     gmTES5: DefineTES5;
     gmFNV: DefineFNV;
     gmTES4: DefineTES4;

--- a/src/xeSetup.pas
+++ b/src/xeSetup.pas
@@ -303,7 +303,7 @@ var
 begin
   wbContainerHandler.AddFolder(wbDataPath);
   bExact := wbGameMode in [gmTES5];
-  bModIni := wbGameMode in [gmTES5, gmSSE];
+  bModIni := wbGameMode in [gmTES5, gmSSE, gmTES5VR];
   slBSAFileNames := TStringList.Create;
   try
     slErrors := TStringList.Create;
@@ -465,7 +465,7 @@ begin
   sPath := sLoadPath + 'plugins.txt';
   if FileExists(sPath) then begin
     sl.LoadFromFile(sPath);
-    if (wbGameMode = gmSSE) or (wbGameMode = gmFO4) then
+    if wbGameMode in [gmFO4VR, gmFO4, gmTES5VR, gmSSE] then
       ProcessPluginsFormat(sl, noDelete);
   end
   else
@@ -481,7 +481,7 @@ var
   sPath: String;
 begin
   sPath := sLoadPath + 'loadorder.txt';
-  if (wbGameMode <> gmSSE) and (wbGameMode <> gmFO4)
+  if not (wbGameMode in [gmFO4VR, gmFO4, gmTES5VR, gmSSE])
   and FileExists(sPath) then
     slLoadOrder.LoadFromFile(sPath)
   else
@@ -621,7 +621,26 @@ begin
     FixLoadOrder(sl, 'Dragonborn.esm', index);
     AddCCPlugins(sl, index);
   end
+  else if (wbGameMode = gmTES5VR) then begin
+    FixLoadOrder(sl, 'Update.esm', index);
+    FixLoadOrder(sl, 'Dawnguard.esm', index);
+    FixLoadOrder(sl, 'HearthFires.esm', index);
+    FixLoadOrder(sl, 'Dragonborn.esm', index);
+    FixLoadOrder(sl, 'SkyrimVR.esm', index);
+    AddCCPlugins(sl, index);
+  end
   else if (wbGameMode = gmFO4) then begin
+    FixLoadOrder(sl, 'DLCRobot.esm', index);
+    FixLoadOrder(sl, 'DLCworkshop01.esm', index);
+    FixLoadOrder(sl, 'DLCCoast.esm', index);
+    FixLoadOrder(sl, 'DLCworkshop02.esm', index);
+    FixLoadOrder(sl, 'DLCworkshop03.esm', index);
+    FixLoadOrder(sl, 'DLCNukaWorld.esm', index);
+    FixLoadOrder(sl, 'DLCUltraHighResolution.esm', index);
+    AddCCPlugins(sl, index);
+  end
+  else if (wbGameMode = gmFO4VR) then begin
+    FixLoadOrder(sl, 'Fallout4_VR.esm', index);
     FixLoadOrder(sl, 'DLCRobot.esm', index);
     FixLoadOrder(sl, 'DLCworkshop01.esm', index);
     FixLoadOrder(sl, 'DLCCoast.esm', index);


### PR DESCRIPTION
The version of xEdit in use already supports VR. We just need to add piping to them.

Note: in the load order fixes for DLC / creation club content, the VR copies of the games normally do not provide DLC, but it is common for users to backport them manually as many flatscreen mods that are desirable to use in VR set them as masters.

Changes can be verified with the build attached to https://github.com/z-edit/zedit/pull/303